### PR TITLE
Resolve #64

### DIFF
--- a/DBConnection/loadPrice.js
+++ b/DBConnection/loadPrice.js
@@ -51,7 +51,7 @@ const loadPrice = async (pool, timeframe, tableName) => {
     })
     const priceResults = await Promise.all(arrOfSymbolPromise)
     priceResults.forEach((ohlc, index) => {
-      const price = ohlc[ohlc.length - 1][4]
+      const price = ohlc[ohlc.length - 1][1]
       const time = ohlc[ohlc.length - 1][0]
       const market = symbols[index]
       const dt = timestampToDate(time)


### PR DESCRIPTION
Hot fix. I think the best way is to load db data when server restart, checking if there is the new bar for settlement price.

In this commit, I use the opening price in UTC00 and it can fix the settlement price double loading issue because the opening price will not change. In result, the settlement price which is double loaded will be the same as previous one when the server restart.